### PR TITLE
Bump the github-actions group with 1 update

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,7 +19,7 @@ jobs:
     name: Validation tests
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: policy-collection
 


### PR DESCRIPTION
Bumps the github-actions group with 1 update: [actions/checkout](https://github.com/actions/checkout).

Updates `actions/checkout` from 3 to 4
- [Release notes](https://github.com/actions/checkout/releases)
- [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
- [Commits](https://github.com/actions/checkout/compare/v3...v4)

---
updated-dependencies:
- dependency-name: actions/checkout dependency-type: direct:production update-type: version-update:semver-major dependency-group: github-actions ...

Signed-off-by: dependabot[bot] <support@github.com>
(cherry picked from commit 658537f716d7c974d54c89eb07f943932607ad8a)

Closes #45 