### PR TITLE
Add an operator policy, kubernetes RBAC policy and virtual machine ex…

### DIFF
--- a/community/OM-Operator-Management/cnv-samples/README.md
+++ b/community/OM-Operator-Management/cnv-samples/README.md
@@ -1,0 +1,11 @@
+# cnv-samples
+### Samples to use with ACM and Container Native Virtualization:
+  * Roll out the OpenShift Virtualization operator to the fleet
+  * Manage kubevirt.io:Edit/View/Admin roles on clusters where the OpenShift Virtualization operator is deployed
+  * YAML definitions for Virtual Machines (using ephemral and persistent PVC's)
+
+### Index
+  * [ACM Operator Policy to install Virtualization](./cnv-operator-install)
+  * [RBAC Policies for OpenShift Virtualization users](./fleet-user-rolebinding-policy)
+  * [Virtual Machine YAML](./virtual-machines)
+

--- a/community/OM-Operator-Management/cnv-samples/cnv-operator-install/README.md
+++ b/community/OM-Operator-Management/cnv-samples/cnv-operator-install/README.md
@@ -1,0 +1,23 @@
+# Install OpenShift Virtualization operator in the Fleet
+
+This Policy for Red Hat Advanced Cluster Management for Kubernetes(ACM) includes an Operator policy. This policy deploys Red Hat operators on the clusters managed by ACM (ManagedClusters). The included placement uses labels to determine which ManagedCluster to apply the Operator policy to. The Operator Policy deploys the OpenShift Virtualization operator and include a Configuration Policy to validate core controllers are online.
+
+* To choose a ManagedCluster as a target for this Container Native Virtualization Operator Policy by applying the label `acm/cnv-operator-install: "true"` to a ManagedCluster in ACM.
+
+### Deploy the Policy
+Apply the policy to the ACM Hub, then add the label `acm/cnv-operator-install: "true"` to the ManagedClusters where you want to deploy Container Native Virtualization operator.
+```
+oc apply -f ./
+```
+
+You may customize the hyperconverged settings in the `policy-cnv.yaml` file. Where you will find:
+  1. Subscription resource details
+  2. ClusterServiceVersion resource details
+  3. HyperConverged resource details
+  4. HostPathProvisioner resource details
+  5. Other status checks that validate the OpenShift Virtualization operator deployed correctly.
+  6. NEW resources can be added to policy to customize the deployment of OpenShift Virtualization
+
+To customize any of these resources in the policy, refer to the [OpenShift Virtualization documentation](https://docs.openshift.com/container-platform/4.17/virt/install/installing-virt.html#virt-subscribing-cli_installing-virt).
+
+Note: The policy is keyed to OCP `v4.18.9` and OpenShift Virtualization `v4.18.2`

--- a/community/OM-Operator-Management/cnv-samples/cnv-operator-install/placement-cnv.yaml
+++ b/community/OM-Operator-Management/cnv-samples/cnv-operator-install/placement-cnv.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: openshift-virtualization
+  namespace: default
+spec:
+  clusterConditions:
+    - status: 'True'
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      - key: "acm/cnv-operator-install"
+        operator: In
+        values:
+          - "true"
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: openshift-virtualization
+  namespace: default
+placementRef:
+  name: openshift-virtualization
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: openshift-virtualization
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io

--- a/community/OM-Operator-Management/cnv-samples/cnv-operator-install/policy-cnv.yaml
+++ b/community/OM-Operator-Management/cnv-samples/cnv-operator-install/policy-cnv.yaml
@@ -1,0 +1,179 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: openshift-virtualization
+  namespace: default
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: kubevirt-namespace
+        spec:
+          remediationAction: enforce
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: "v1"
+                kind: "Namespace"
+                metadata:
+                  name: "openshift-cnv"
+            
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1beta1
+        kind: OperatorPolicy
+        metadata:
+          name: kubevirt-hyperconverged-operator
+        spec:
+          remediationAction: enforce
+          complianceType: musthave
+          operatorGroup: # optional
+            name: openshift-cnv
+            namespace: openshift-cnv
+            targetNamespaces:
+                - openshift-cnv
+          subscription:
+            channel: stable
+            name: kubevirt-hyperconverged
+            namespace: openshift-cnv
+            #source: redhat-operators
+            #sourceNamespace: openshift-marketplace
+            startingCSV: kubevirt-hyperconverged-operator.v4.17.3
+            #installPlanApproval: Automatic
+          upgradeApproval: Automatic
+          versions:
+          - kubevirt-hyperconverged-operator.v4.17.3
+# Create the hyperconverged Custom Resource below
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: openshift-virtualization-deployment
+        spec:
+          remediationAction: enforce
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: hco.kubevirt.io/v1beta1
+                kind: HyperConverged
+                metadata:
+                  name: kubevirt-hyperconverged
+                  annotations:
+                    deployOVS: 'false'
+                  namespace: openshift-cnv
+                spec:
+                  virtualMachineOptions:
+                    disableFreePageReporting: false
+                    disableSerialConsoleLog: true
+                  higherWorkloadDensity:
+                    memoryOvercommitPercentage: 100
+                  liveMigrationConfig:
+                    allowAutoConverge: false
+                    allowPostCopy: false
+                    completionTimeoutPerGiB: 800
+                    parallelMigrationsPerCluster: 5
+                    parallelOutboundMigrationsPerNode: 2
+                    progressTimeout: 150
+                  certConfig:
+                    ca:
+                      duration: 48h0m0s
+                      renewBefore: 24h0m0s
+                    server:
+                      duration: 24h0m0s
+                      renewBefore: 12h0m0s
+                  applicationAwareConfig:
+                    allowApplicationAwareClusterResourceQuota: false
+                    vmiCalcConfigName: DedicatedVirtualResources
+                  featureGates:
+                    deployTektonTaskResources: false
+                    enableCommonBootImageImport: true
+                    withHostPassthroughCPU: false
+                    downwardMetrics: false
+                    disableMDevConfiguration: false
+                    enableApplicationAwareQuota: false
+                    deployKubeSecondaryDNS: false
+                    nonRoot: true
+                    alignCPUs: false
+                    enableManagedTenantQuota: false
+                    primaryUserDefinedNetworkBinding: false
+                    deployVmConsoleProxy: false
+                    persistentReservation: false
+                    autoResourceLimits: false
+                    deployKubevirtIpamController: false
+                  workloadUpdateStrategy:
+                    batchEvictionInterval: 1m0s
+                    batchEvictionSize: 10
+                    workloadUpdateMethods:
+                      - LiveMigrate
+                  uninstallStrategy: BlockUninstallIfWorkloadsExist
+                  resourceRequirements:
+                    vmiCPUAllocationRatio: 10
+# Fix our KVM_EMULATION setting on the Subscription
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: operators.coreos.com/v1alpha1
+                kind: ClusterServiceVersion
+                metadata:
+                  name: kubevirt-hyperconverged-operator.v4.17.3
+                  namespace: openshift-cnv
+                spec:
+                  install:
+                    spec:  
+                      deployments:
+                        - name: hco-operator
+                          spec:
+                            template:  
+                              spec:
+                                containers:
+                                  - name: hyperconverged-cluster-operator
+                                    env:
+                                    - name: KVM_EMULATION
+                                      value: 'false'
+
+# Hostpath provisioner
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: hostpathprovisioner.kubevirt.io/v1beta1
+                kind: HostPathProvisioner
+                metadata:
+                  name: hostpath-provisioner
+                spec:
+                  imagePullPolicy: IfNotPresent
+                  storagePools:
+                    - name: local
+                      path: /var/hpvolumes
+                      pvcTemplate:
+                        accessModes:
+                          - ReadWriteOnce
+                        resources:
+                          requests:
+                            storage: 50Gi
+                  workload:
+                    nodeSelector:
+                      kubernetes.io/os: linux
+
+#Validate that things are installed
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: kubevirt-hyperconverged-available
+        spec:
+          remediationAction: inform
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: hco.kubevirt.io/v1beta1
+                kind: HyperConverged
+                metadata:
+                  name: kubevirt-hyperconverged
+                  namespace: openshift-cnv
+                status:
+                  conditions:
+                    - message: Reconcile completed successfully
+                      reason: ReconcileCompleted
+                      status: 'True'
+                    - type: Available

--- a/community/OM-Operator-Management/cnv-samples/fleet-user-rolebinding-policy/README.md
+++ b/community/OM-Operator-Management/cnv-samples/fleet-user-rolebinding-policy/README.md
@@ -1,0 +1,17 @@
+# Applying RBAC to ACM managed CNV clusters
+OpenShift Virtualization has three predefined roles that you can bind to users or groups.
+  * kubevirt.io:view
+  * kubevirt.io:edit
+  * kubevirt.io:admin
+
+When OIDC is configured, supplying a `RoleBinding` or `ClusterRoleBinding`, with the **subject** and **clusterRole / role** allows the subject access to virtual machines in the namespace or on the cluster. The included policy creates users and assigns those users as **subjects** in a `clusterRoleBinding` (cluster wide) with the **ClusterRole** permissions of **kubevirt.io:edit**.
+
+Any cluster that used the OpenShift Virtualization operator policy provided here, by adding the label `acm/cnv-operator-install: "true"` will also receive the `clusterRoleBinding` and **Users** defined in this policy if it is applied to ACM
+
+### Deploythe policy
+```
+  oc apply -f ./acm-kubevirt-edit-fleet.yaml
+```
+
+### Notes
+* This will be a ClusterPermission in Advanced Cluster Managemenet for Kubernetes v2.15

--- a/community/OM-Operator-Management/cnv-samples/fleet-user-rolebinding-policy/acm-kubevirt-edit-fleet.yaml
+++ b/community/OM-Operator-Management/cnv-samples/fleet-user-rolebinding-policy/acm-kubevirt-edit-fleet.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: acm-kubevirt-edit-fleet
+  namespace: default
+  annotations:
+    policy.open-cluster-management.io/categories: AC Access Control
+    policy.open-cluster-management.io/controls: AC-3 Access Enforcement
+    policy.open-cluster-management.io/description: This is the virt.k8s.io:edit ClusterRole for all CNV managed clusters
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+spec:
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: policy-rolebinding
+        spec:
+          namespaceSelector:
+            exclude:
+              - kube-*
+            include:
+              - default
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: rbac.authorization.k8s.io/v1
+                kind: ClusterRoleBinding
+                metadata:
+                  name: acm-kubevirt-edit
+                roleRef:
+                  name: kubevirt.io:edit
+                  apiGroup: rbac.authorization.k8s.io
+                  kind: ClusterRole
+                subjects:
+                  - name: jnpacker
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: User
+                  - name: davidvossel
+                    apiGroup: rbac.authorization.k8s.io
+                    kind: User
+            - complianceType: musthave
+              objectDefinition:
+                kind: User
+                apiVersion: user.openshift.io/v1
+                metadata:
+                  name: virtuser01
+                fullName: Virtual User 01
+                groups: null
+            - complianceType: musthave
+              objectDefinition:
+                kind: User
+                apiVersion: user.openshift.io/v1
+                metadata:
+                  name: virtuser02
+                fullName: Virtual User 02
+                groups: null
+          remediationAction: inform
+          severity: high
+  remediationAction: enforce
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: acm-virt-edit-fleet-placement
+  namespace: default
+placementRef:
+  name: openshift-virtualization
+  apiGroup: apps.open-cluster-management.io
+  kind: PlacementRule
+subjects:
+  - name: acm-kubevirt-edit-fleet
+    apiGroup: policy.open-cluster-management.io
+    kind: Policy

--- a/community/OM-Operator-Management/cnv-samples/virtual-machines/README.md
+++ b/community/OM-Operator-Management/cnv-samples/virtual-machines/README.md
@@ -1,0 +1,7 @@
+# Virtual Machine YAML definitions
+
+Before applying the YAML, make the following changes:
+  1. Change the virtual machine name
+  2. Set the `password` and `ssh_authorized_keys`(optional, uncomment) in the `userData` section
+  3. Apply the yaml with `oc apply -f`
+  4. Once the Virtual Machine instance is created, start the virtual machine to complete the setup

--- a/community/OM-Operator-Management/cnv-samples/virtual-machines/fedora-rootdisk-and-datadisk.yaml
+++ b/community/OM-Operator-Management/cnv-samples/virtual-machines/fedora-rootdisk-and-datadisk.yaml
@@ -1,0 +1,79 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: vm02
+  namespace: default
+spec:
+  dataVolumeTemplates:
+    - metadata:
+        creationTimestamp: null
+        name: fedora-vm01
+      spec:
+        sourceRef:
+          kind: DataSource
+          name: fedora
+          namespace: openshift-virtualization-os-images
+        storage:
+          resources:
+            requests:
+              storage: '32212254720'
+          storageClassName: managed-csi
+    - metadata:
+        creationTimestamp: null
+        name: dv-fedora-vm01
+      spec:
+        source:
+          blank: {}
+        storage:
+          resources:
+            requests:
+              storage: 30Gi
+          storageClassName: managed-csi
+  instancetype:
+    kind: virtualmachineclusterinstancetype
+    name: u1.small
+  preference:
+    kind: virtualmachineclusterpreference
+    name: fedora
+  runStrategy: Halted
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        network.kubevirt.io/headlessService: headless
+    spec:
+      architecture: amd64
+      domain:
+        devices:
+          autoattachPodInterface: false
+          disks:
+            - disk:
+                bus: virtio
+              name: disk-vm01
+          interfaces:
+            - masquerade: {}
+              name: default
+        machine:
+          type: pc-q35-rhel9.4.0
+        resources: {}
+      networks:
+        - name: default
+          pod: {}
+      subdomain: headless
+      volumes:
+        - dataVolume:
+            name: fedora-vm01
+          name: rootdisk
+        - cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              chpasswd:
+                expire: false
+              password: change-me-5738
+              user: fedora
+              #ssh_authorized_keys:
+              #  - ssh-rsa ssh-rsa...
+          name: cloudinitdisk
+        - dataVolume:
+            name: dv-fedora-vm01
+          name: disk-vm01

--- a/community/OM-Operator-Management/cnv-samples/virtual-machines/fedora-rootdisk-only.yaml
+++ b/community/OM-Operator-Management/cnv-samples/virtual-machines/fedora-rootdisk-only.yaml
@@ -1,0 +1,61 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: vm01
+  namespace: default
+spec:
+  dataVolumeTemplates:
+    - metadata:
+        creationTimestamp: null
+        name: fedora-vm01
+      spec:
+        sourceRef:
+          kind: DataSource
+          name: fedora
+          namespace: openshift-virtualization-os-images
+        storage:
+          resources:
+            requests:
+              storage: '32212254720'
+          storageClassName: managed-csi
+  instancetype:
+    kind: virtualmachineclusterinstancetype
+    name: u1.small
+  preference:
+    kind: virtualmachineclusterpreference
+    name: fedora
+  runStrategy: Halted
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        network.kubevirt.io/headlessService: headless
+    spec:
+      architecture: amd64
+      domain:
+        devices:
+          autoattachPodInterface: false
+          interfaces:
+            - masquerade: {}
+              name: default
+        machine:
+          type: pc-q35-rhel9.4.0
+        resources: {}
+      networks:
+        - name: default
+          pod: {}
+      subdomain: headless
+      volumes:
+        - dataVolume:
+            name: fedora-vm01
+          name: rootdisk
+        - cloudInitNoCloud:
+            userData: |
+              #cloud-config
+              chpasswd:
+                expire: false
+              password: change-me-5738
+              user: fedora
+              #ssh_authorized_keys:
+              #  - ssh-rsa ssh-rsa...
+          name: cloudinitdisk


### PR DESCRIPTION
…amples.

1. Policy deploys the CNV Operator
2. There are also configuration policies that check to make sure controllers and subscription are happy path
3. There is an extra policy template to set KVM_EMULATION: true if you want to run demos on NON-virtualization hardware, It is `false` by default.
4. A configuration Policy for applying the 3x kubevirt roles to a user/group/serviceAccount (this will be updated to a clusterPermission in the future.
5. Two example yamls for create VM's, this is to help get the users started. One with just a rootdisk, and one with rootdisk & datadisk.