### PR TITLE
changed channel for acs central to 'stable'

### DIFF
--- a/community/CM-Configuration-Management/policy-acs-operator-central.yaml
+++ b/community/CM-Configuration-Management/policy-acs-operator-central.yaml
@@ -58,7 +58,7 @@ spec:
                   name: rhacs-operator
                   namespace: rhacs-operator
                 spec:
-                  channel: latest
+                  channel: stable
                   installPlanApproval: Automatic
                   name: rhacs-operator
                   source: redhat-operators


### PR DESCRIPTION
added 'stable' channel so policy will install latest stable ACS operator.