### PR TITLE
Fix Quay Clair HPA overscaling during CVE database initialization

### DIFF
--- a/policygenerator/policy-sets/stable/openshift-plus/input-quay/policy-install-quay.yaml
+++ b/policygenerator/policy-sets/stable/openshift-plus/input-quay/policy-install-quay.yaml
@@ -101,3 +101,24 @@ spec:
       managed: true
     - managed: true
       kind: tls
+    - kind: horizontalpodautoscaler
+      managed: false
+    - kind: quay
+      managed: true
+      overrides:
+        replicas: null
+    - kind: clair
+      managed: true
+      overrides:
+        replicas: null
+        resources:
+          requests:
+            memory: 8Gi
+            cpu: "4"
+          limits:
+            memory: 16Gi
+            cpu: "8"
+    - kind: mirror
+      managed: true
+      overrides:
+        replicas: null


### PR DESCRIPTION
  - Disable HPA for Clair component to prevent overscaling
  - Use fixed 1 replica instead of autoscaling
  - Update resource limits for Clair deployment
  - Follow Quay documentation best practices for HPA configuration https://docs.redhat.com/en/documentation/red_hat_quay/3/html/deploying_the_red_hat_quay_operator_on_openshift_container_platform/configuring-the-database-poc#operator-unmanaged-hpa