### PR TITLE
[release-2.17] chore: sync common makefiles for go 1.26

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,39 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: cron
+      cronjob: "0 7 * * MON#1"
+      timezone: America/New_York
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 14
     groups:
       github-actions:
         patterns:
           - "*"
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: cron
+      cronjob: "0 7 * * MON#1"
+      timezone: America/New_York
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-minor-days: 14
+    groups:
+      gomod:
+        patterns:
+          - "*"
+    allow:
+      - dependency-type: all
+    ignore:
+      - dependency-name: "k8s.io/*"
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
+      - dependency-name: "*.k8s.io/*"
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor


### PR DESCRIPTION
ref: https://redhat.atlassian.net/browse/ACM-35531