### PR TITLE
Fix OCP 5.0 semver version check in machine-sets.yaml

### DIFF
--- a/policygenerator/policy-sets/community/openshift-plus-setup/machine-sets.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus-setup/machine-sets.yaml
@@ -101,7 +101,7 @@ spec:
                       values:
                       - '{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").status.infrastructureName }}-worker-sg'
                   {{- $ocpversion := semver (fromClusterClaim "version.openshift.io") }}
-                  {{- if gt $ocpversion.Minor 15 }}
+                  {{- if or (gt $ocpversion.Major 4) (gt $ocpversion.Minor 15) }}
                   - filters:
                     - name: tag:Name
                       values:
@@ -116,7 +116,7 @@ spec:
                     - name: tag:Name
                       values:
                       - '{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").status.infrastructureName }}-private-{{ list (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").status.platformStatus.aws.region $zone | join "" }}'
-                  {{- if gt $ocpversion.Minor 15 }}
+                  {{- if or (gt $ocpversion.Major 4) (gt $ocpversion.Minor 15) }}
                       - '{{ (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").status.infrastructureName }}-subnet-private-{{ list (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").status.platformStatus.aws.region $zone | join "" }}'
                   {{- end }}
                   tags:


### PR DESCRIPTION
Fixes ACM-38256

The semver version check `gt $ocpversion.Minor 15` incorrectly evaluates
to false for OCP 5.0 (Minor=0), causing the policy to use legacy
`-worker-sg` security group names that don't exist on 5.0 clusters.
This results in 100% MachineSet launch failures on OCP 5.0/AWS.

Fix: Add `or (gt $ocpversion.Major 4)` to both version checks at lines
104 and 119 of machine-sets.yaml, so OCP 5.0+ correctly uses new-style
security group and subnet names while preserving 4.x backward compat.

Evidence:
- Failed CI job: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-stolostron-policy-collection-main-ocp5.0-interop-opp-aws/2081470534922539008
- INTEROP tracking: https://redhat.atlassian.net/browse/INTEROP-9372
- Related MCO hot-loop issue: https://redhat.atlassian.net/browse/OCPBUGS-84704

Signed-off-by: Michael Pruitt <mpruitt@redhat.com>