### PR TITLE
Sync 560 from ocm-io

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -54,6 +54,6 @@ jobs:
 
       - name: Upload SARIF file
         if: always() && env.LINT_VIOLATIONS == 'true'
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@v4.37.4
         with:
           sarif_file: merged.sarif


### PR DESCRIPTION
Bumps the github-actions group with 1 update: [github/codeql-action](https://github.com/github/codeql-action).

Updates `github/codeql-action` from 4 to 4.37.4
- [Release notes](https://github.com/github/codeql-action/releases)
- [Changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md)
- [Commits](https://github.com/github/codeql-action/compare/v4...v4.37.4)

---
updated-dependencies:
- dependency-name: github/codeql-action dependency-version: 4.37.4 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: github-actions ...


(cherry picked from commit 4c60de66310290afc525b3cea2b2ef1e8e3f1143)

Closes https://github.com/stolostron/policy-collection/issues/171