### PR TITLE
fix: remove MSBIC-managed fields from AWS MachineSet providerSpec

### DIFF
--- a/policygenerator/policy-sets/community/openshift-plus-setup/machine-sets.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus-setup/machine-sets.yaml
@@ -6,10 +6,6 @@
 # More details on installing OCS including the creation of the MachineSets is located here:
 # https://red-hat-storage.github.io/ocs-training/training/ocs4/ocs.html#_scale_ocp_cluster_and_add_new_worker_nodes
 #
-# This policy contains an Amazon Machine Identifier which must be updated in the policy.  Obtain the AMI id from:
-# https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/installing/installing-on-aws#installation-aws-user-infra-rhcos-ami_installing-aws-user-infra
-# AMI IDs are provided in a settings configmap which can be adjusted as desired.
-#
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
@@ -51,25 +47,7 @@ spec:
                   node-role.kubernetes.io/worker: ""
               providerSpec:
                 value:
-                  ami:
-                    id: '{{- $dynamicAMI := "" -}}
-                         {{- $machinesets := (lookup "machine.openshift.io/v1beta1" "MachineSet" "openshift-machine-api" "") -}}
-                         {{- if $machinesets.items -}}
-                           {{- if gt (len $machinesets.items) 0 -}}
-                             {{- $dynamicAMI = (index $machinesets.items 0).spec.template.spec.providerSpec.value.ami.id -}}
-                           {{- end -}}
-                         {{- end -}}
-                         {{- if $dynamicAMI -}}
-                           {{ $dynamicAMI }}
-                         {{- else -}}
-                           {{ fromConfigMap "policies" "opp-settings" (printf "%s-%s" (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").status.platformStatus.aws.region (fromClusterClaim "openshiftversion-major-minor")) }}
-                         {{- end -}}'
                   apiVersion: awsproviderconfig.openshift.io/v1beta1
-                  blockDevices:
-                  - ebs:
-                      iops: 0
-                      volumeSize: 120
-                      volumeType: gp3
                   credentialsSecret:
                     name: aws-cloud-credentials
                   deviceIndex: 0
@@ -172,6 +150,9 @@ spec:
                   numCPUs: '{{ fromConfigMap "policies" "opp-settings" "vmwareCPU" | toInt }}'
                   numCoresPerSocket: 4
                   snapshot: ""
+                  # TODO: The template field is managed by MCO's MachineSet Boot Image Controller (MSBIC)
+                  # starting in OCP 4.19. Enforcing it here may cause the same hot-loop contention
+                  # seen with ami.id/blockDevices on AWS. Evaluate removing this field. (ACM-38256)
                   template: {{ (index (split "/" (index (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").spec.platformSpec.vsphere.failureDomains 0).topology.template) "_3") }}
                   userDataSecret:
                     name: worker-user-data


### PR DESCRIPTION
## Summary

Remove `ami.id` and `blockDevices` from the AWS MachineSet `providerSpec` template
in `machine-sets.yaml` to resolve a deterministic MCO hot loop on OCP 4.19+/5.0.

## Problem

Since OCP 4.19, MCO's MachineSet Boot Image Controller (MSBIC) is enabled by
default (MCO-1361). MSBIC patches `ami.id` and `blockDevices` on all MachineSets
to keep boot images aligned with the `coreos-bootimages` configmap.

The `opp-storage-machinesets` ConfigurationPolicy enforces these same fields via
`complianceType: musthave` / `remediationAction: enforce`, creating a hot loop:

1. MCO MSBIC patches `ami.id` and `blockDevices` on `workerocs` MachineSets
2. ACM policy reverts the patch to the originally-observed values
3. After 3 revert cycles, MCO declares the MachineSet Degraded (OCPBUGS-55967)
4. `machine-config` ClusterOperator reports Degraded → CI health check fails

Evidence: default worker MachineSets have `generation=1` while `workerocs`
MachineSets show `generation=7-8` (1 create + 3 MCO patches + 3 ACM reverts).

## Fix

Remove the two MSBIC-managed field blocks from the AWS providerSpec template:
- `ami:` block (dynamic AMI lookup + configmap fallback) — 13 lines
- `blockDevices:` block (ebs iops/volumeSize/volumeType) — 5 lines

MCO MSBIC will populate these fields automatically after MachineSet creation.
All other policy-managed fields are preserved.

A TODO comment is added near the vSphere `template:` field, which is also
MSBIC-managed and may need similar treatment in a follow-up.

## References

- [ACM-38256](https://redhat.atlassian.net/browse/ACM-38256) — tracking bug for OCP 5.0 machine-sets.yaml compatibility
- [OCPBUGS-55638](https://redhat.atlassian.net/browse/OCPBUGS-55638) — MCO/GitOps boot image contention pattern
- [OCPBUGS-55967](https://redhat.atlassian.net/browse/OCPBUGS-55967) — MSBIC hot loop detection (Degraded after 3 cycles)
- [OCPBUGS-84704](https://redhat.atlassian.net/browse/OCPBUGS-84704) — upstream MCO+GitOps conflict tracker
- [INTEROP-9409](https://redhat.atlassian.net/browse/INTEROP-9409) — OPP interop CI blocker
- [PR #169](https://github.com/stolostron/policy-collection/pull/169) — prior fix for semver version check (did not address boot images)

[ACM-38256]: https://redhat.atlassian.net/browse/ACM-38256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ