### PR TITLE
INTEROP-9433: Fix MSBIC hot loop on workerocs MachineSets

### DIFF
--- a/policygenerator/policy-sets/community/openshift-plus-setup/machine-sets.yaml
+++ b/policygenerator/policy-sets/community/openshift-plus-setup/machine-sets.yaml
@@ -6,9 +6,9 @@
 # More details on installing OCS including the creation of the MachineSets is located here:
 # https://red-hat-storage.github.io/ocs-training/training/ocs4/ocs.html#_scale_ocp_cluster_and_add_new_worker_nodes
 #
-# This policy contains an Amazon Machine Identifier which must be updated in the policy.  Obtain the AMI id from:
-# https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/installing/installing-on-aws#installation-aws-user-infra-rhcos-ami_installing-aws-user-infra
-# AMI IDs are provided in a settings configmap which can be adjusted as desired.
+# AMI IDs are sourced dynamically from the coreos-bootimages ConfigMap in the
+# openshift-machine-config-operator namespace (the MCO's own source of truth).
+# Existing workerocs MachineSets keep their current AMI to avoid conflicts with MSBIC.
 #
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
@@ -52,24 +52,12 @@ spec:
               providerSpec:
                 value:
                   ami:
-                    id: '{{- $dynamicAMI := "" -}}
-                         {{- $machinesets := (lookup "machine.openshift.io/v1beta1" "MachineSet" "openshift-machine-api" "") -}}
-                         {{- if $machinesets.items -}}
-                           {{- if gt (len $machinesets.items) 0 -}}
-                             {{- $dynamicAMI = (index $machinesets.items 0).spec.template.spec.providerSpec.value.ami.id -}}
-                           {{- end -}}
-                         {{- end -}}
-                         {{- if $dynamicAMI -}}
-                           {{ $dynamicAMI }}
-                         {{- else -}}
-                           {{ fromConfigMap "policies" "opp-settings" (printf "%s-%s" (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").status.platformStatus.aws.region (fromClusterClaim "openshiftversion-major-minor")) }}
-                         {{- end -}}'
+                    id: '{{- $region := (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").status.platformStatus.aws.region -}}
+                         {{- $msName := printf "%s-workerocs-%s%s" (lookup "config.openshift.io/v1" "Infrastructure" "" "cluster").status.infrastructureName $region $zone -}}
+                         {{- $bootImages := fromJson (fromConfigMap "openshift-machine-config-operator" "coreos-bootimages" "stream") -}}
+                         {{- $ami_default := (index $bootImages "architectures" "x86_64" "images" "aws" "regions" $region "image") -}}
+                         {{- dig "spec" "template" "spec" "providerSpec" "value" "ami" "id" $ami_default (lookup "machine.openshift.io/v1beta1" "MachineSet" "openshift-machine-api" $msName) -}}'
                   apiVersion: awsproviderconfig.openshift.io/v1beta1
-                  blockDevices:
-                  - ebs:
-                      iops: 0
-                      volumeSize: 120
-                      volumeType: gp3
                   credentialsSecret:
                     name: aws-cloud-credentials
                   deviceIndex: 0


### PR DESCRIPTION
## Summary

- Fixes a hot reconciliation loop between the `machine-sets.yaml` policy template and the MCO MachineSet Boot Image Controller (MSBIC), which causes 100% failure on OPP 5.0 interop jobs.
- AMI ID sourcing changed from hardcoded lookup of the first MachineSet to a dynamic approach: existing workerocs MachineSets keep their current AMI (via `dig`), new ones fall back to the `coreos-bootimages` ConfigMap (MCO's source of truth).
- `blockDevices` enforcement removed entirely since MSBIC manages root volume spec.

## Root Cause

The policy enforced `ami.id` and `blockDevices` via `complianceType: musthave` on workerocs MachineSets. MSBIC (enabled by default since OCP 4.19) actively manages these same fields, creating a hot loop that degrades MCO and blocks CVO.

## Related Issues

- [ACM-38256](https://redhat.atlassian.net/browse/ACM-38256) — MSBIC hot loop blocker
- [OCPBUGS-84704](https://redhat.atlassian.net/browse/OCPBUGS-84704) — MCO+GitOps hot loop conflict
- [INTEROP-9433](https://redhat.atlassian.net/browse/INTEROP-9433) — Task tracker

## Test Plan

- [ ] OPP 5.0 interop job passes MachineSet creation/reconciliation phase without MCO degradation
- [ ] workerocs MachineSets retain their existing AMI after policy application
- [ ] New MachineSets receive AMI from `coreos-bootimages` ConfigMap

[ACM-38256]: https://redhat.atlassian.net/browse/ACM-38256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OCPBUGS-84704]: https://redhat.atlassian.net/browse/OCPBUGS-84704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INTEROP-9433]: https://redhat.atlassian.net/browse/INTEROP-9433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ